### PR TITLE
fix: defined node engine for vercel [ECO-1754]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
         "tslint": "^6.1.3",
         "typescript": "^4.8.4",
         "yargs": "^17.5.1"
+      },
+      "engines": {
+        "node": "^14 || ^16"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "lint": "ng lint",
     "config": "ts-node setenv.ts"
   },
+  "engines": {
+    "node": "^14 || ^16"
+  },
   "license": "MIT",
   "author": "Contentstack",
   "dependencies": {


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1cbhGp1U4UtsPjlijJAciucMuihOyh08%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Sz7frEA)
### Title - define node engines
### Change- updated package json to support vercel deploy
### Story-[ECO-1754]